### PR TITLE
Better error reporting when missing pkgcloud-cli.json sections

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -45,7 +45,7 @@ exports.init = function(config, type, callback) {
     return callback(new Error('No config file specified.  See -h for assistance'));
   }
   config = loadConfig(config);
-  assertSectionInConfigFile(config, type);
+  assertSectionInConfigFile(config, type.toLowerCase());
   if (type === CLIENT_TYPES.compute) {
     client = cloud.compute.createClient(config.compute[0]);
   }


### PR DESCRIPTION
Fix for #5
Adds a check to make sure the section is defined in the pkgcloud-cli.json file.
