### PR TITLE
Update pkgcloud-cli to use pkgcloud 1.0

### DIFF
--- a/bin/pkgcloud-compute-flavor-list
+++ b/bin/pkgcloud-compute-flavor-list
@@ -9,7 +9,7 @@ program
 
 var config = program.config;
 if (!config) {
-  config = process.env['HOME']+'/pkgcloud-cli.json';
+  config = process.env.HOME+'/pkgcloud-cli.json';
 }
 
 var outputFlavors = function(err, flavors) {
@@ -19,7 +19,7 @@ var outputFlavors = function(err, flavors) {
   }
   var tbl = new table({
     head: ['ID', 'NAME', 'RAM', 'DISK', 'VCPUS'],
-    colWidths: [15, 30, 10, 10, 10]
+    colWidths: [20, 30, 10, 10, 10]
   });
   for (var iter in flavors) {
     var flv = flavors[iter];

--- a/bin/pkgcloud-storage-download
+++ b/bin/pkgcloud-storage-download
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 var program = require('commander');
 var helpers = require('../helpers');
-var table   = require('cli-table');
 var path    = require('path');
-var _       = require('underscore');
 
 program
   .option('-c, --containerName <Container Name>', 'Unique Container Name')
@@ -12,9 +10,8 @@ program
   .parse(process.argv);
 
 var config = program.config;
-var containerObj;
 if (!config) {
-  config = process.env['HOME']+'/pkgcloud-cli.json';
+  config = process.env.HOME+'/pkgcloud-cli.json';
 }
 
 
@@ -29,7 +26,7 @@ var getFileDetails = function (err, file) {
 helpers.init(config, helpers.CLIENT_TYPES.storage, function(err, client) {
   if (!program.containerName) {
     console.log('You must specify a container name');
-    process.exit(1)
+    process.exit(1);
   }
   if (!program.file) {
     console.log('You must specify a file to download');

--- a/bin/pkgcloud-storage-upload
+++ b/bin/pkgcloud-storage-upload
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 var program = require('commander');
 var helpers = require('../helpers');
-var table   = require('cli-table');
 var path    = require('path');
-var _       = require('underscore');
+var fs      = require('fs');
 
 program
   .option('-c, --containerName <Container Name>', 'Unique Container Name')
@@ -12,38 +11,43 @@ program
   .parse(process.argv);
 
 var config = program.config;
-var containerObj;
 if (!config) {
-  config = process.env['HOME']+'/pkgcloud-cli.json';
+  config = process.env.HOME+'/pkgcloud-cli.json';
 }
-
-
-var getFileDetails = function (err, file) {
-  if (err || !file) {
-    console.log(err.message || 'File not uploaded successfully');
-    process.exit(1);
-  }
-  console.log('File has been uploaded successfully');
-};
 
 helpers.init(config, helpers.CLIENT_TYPES.storage, function(err, client) {
   if (!program.containerName) {
     console.log('You must specify a container name');
-    process.exit(1)
+    process.exit(1);
   }
   if (!program.fileName && !program.input) {
     console.log('You must specify a file name or an input to upload');
     process.exit(1);
   }
-  var options = {
-    container: program.containerName,
-    remote: program.fileName || path.basename(program.input)
-  };
+
+  var readStream;
+  var filename;
   if (program.input) {
-    options.local = path.resolve(program.input);
+    readStream = fs.createReadStream(program.input);
+    filename = program.fileName || path.basename(program.input);
   }
-  var fStream = client.upload(options, getFileDetails);
-  if (!program.input) {
-    process.stdin.pipe(fStream);
+  else { // file data coming from stdin
+    readStream = process.stdin;
+    filename = program.fileName;
   }
+  var writeStream = client.upload({
+    container: program.containerName,
+    remote: filename
+  });
+
+  writeStream.on('error', function(err) {
+    console.log(err.message || 'File not uploaded successfully');
+    process.exit(1);
+  });
+
+  writeStream.on('success', function(file) {
+    console.log('File',file.name,'has been uploaded successfully');
+  });
+
+  readStream.pipe(writeStream);
 });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "pkgcloud-cli",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "CLI for pkgcloud",
   "scripts": {
     "test": "make test"
   },
   "engines": {
-    "node": ">= 0.8.x"
+    "node": ">= 0.10.x"
   },
   "bin": {
     "pkgcloud": "./bin/pkgcloud",
@@ -55,7 +55,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "~2.0.0",
-    "pkgcloud": "~0.9.5",
+    "pkgcloud": "~1.0.2",
     "nconf": "~0.6.7",
     "path": "~0.4.9",
     "cli-table": "~0.3.0",


### PR DESCRIPTION
This PR updates pkgcloud-cli to use pkgcloud v1.0 and bumps the pkgcloud-cli version to 1.0.0.
